### PR TITLE
Removed all nLogin advertising and promotion code.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew clean build --full-stacktrace
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Artifacts
         path: openlogin-universal/build/libs/OpenLogin.jar

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 8
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: '21'
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
     - name: Build with Gradle
-      run: ./gradlew build --full-stacktrace
+      run: ./gradlew clean build --full-stacktrace
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:

--- a/openlogin-bukkit/src/main/java/com/nickuc/openlogin/bukkit/command/executors/OpenLoginCommand.java
+++ b/openlogin-bukkit/src/main/java/com/nickuc/openlogin/bukkit/command/executors/OpenLoginCommand.java
@@ -44,8 +44,7 @@ public class OpenLoginCommand extends BukkitAbstractCommand {
     private final AtomicBoolean
             downloadLock = new AtomicBoolean(),
             confirmNLogin = new AtomicBoolean(),
-            confirmOpenLogin = new AtomicBoolean(),
-            confirmAd = new AtomicBoolean();
+            confirmOpenLogin = new AtomicBoolean();
 
     public OpenLoginCommand(OpenLoginBukkit plugin) {
         super(plugin, "openlogin");
@@ -89,29 +88,6 @@ public class OpenLoginCommand extends BukkitAbstractCommand {
                         sender.sendMessage("§cDownload in progress...");
                     } else if (!update(player)) {
                         downloadLock.set(false);
-                    }
-                    return;
-                }
-
-                case "nlogin_ad": {
-                    if (!(sender instanceof Player)) {
-                        sender.sendMessage(Messages.PLAYER_COMMAND_USAGE.asString());
-                        return;
-                    }
-
-                    if (!confirmAd.getAndSet(true)) {
-                        sender.sendMessage("");
-                        sender.sendMessage(" §cnLogin is generally a better solution for most users.");
-                        sender.sendMessage(" §7If you want to keep §fOpeNLogin §7anyway,");
-                        sender.sendMessage(" §7please click on the message again.");
-                        sender.sendMessage("");
-                        return;
-                    }
-
-                    if (plugin.getPluginSettings().set("nlogin_ad", Long.toString(System.currentTimeMillis()))) {
-                        sender.sendMessage("§eYou will not be notified again of the migration for a long time.");
-                    } else {
-                        sender.sendMessage("§cDatabase error :C, please try again.");
                     }
                     return;
                 }

--- a/openlogin-bukkit/src/main/java/com/nickuc/openlogin/bukkit/listener/PlayerAuthenticateListener.java
+++ b/openlogin-bukkit/src/main/java/com/nickuc/openlogin/bukkit/listener/PlayerAuthenticateListener.java
@@ -26,8 +26,6 @@ package com.nickuc.openlogin.bukkit.listener;
 
 import com.nickuc.openlogin.bukkit.OpenLoginBukkit;
 import com.nickuc.openlogin.bukkit.api.events.AsyncAuthenticateEvent;
-import com.nickuc.openlogin.bukkit.util.TextComponentMessage;
-import com.nickuc.openlogin.common.util.ClassUtils;
 import lombok.AllArgsConstructor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -59,18 +57,6 @@ public class PlayerAuthenticateListener implements Listener {
                 player.sendMessage(" §7A new version of §aOpeNLogin §7is available §a(v" + plugin.getDescription().getVersion() + " -> " + plugin.getLatestVersion() + ")§7.");
                 player.sendMessage(" §7Use the command §f'/openlogin update' §7to download new version.");
                 player.sendMessage("");
-            } else if (!plugin.isNewUser() &&
-                    ClassUtils.exists("net.md_5.bungee.api.chat.TextComponent") &&
-                    System.currentTimeMillis() - Long.parseLong(plugin.getPluginSettings().read("setup_date", "0")) > 7 * 86400 * 1000L) { // 7 days
-                String value = plugin.getPluginSettings().read("nlogin_ad");
-                if (value != null) {
-                    long timestamp = Long.parseLong(value);
-                    if (timestamp != -1 && System.currentTimeMillis() - timestamp > 30 * 86400 * 1000L) { // 30 days
-                        TextComponentMessage.sendPluginAd(player);
-                    }
-                } else {
-                    TextComponentMessage.sendPluginAd(player);
-                }
             }
         }
     }

--- a/openlogin-bukkit/src/main/java/com/nickuc/openlogin/bukkit/util/TextComponentMessage.java
+++ b/openlogin-bukkit/src/main/java/com/nickuc/openlogin/bukkit/util/TextComponentMessage.java
@@ -72,46 +72,4 @@ public class TextComponentMessage {
         spigot.sendMessage(second);
     }
 
-    public static void sendPluginAd(Player player) {
-        TextComponent first = new TextComponent("      ");
-
-        TextComponent nlogin = new TextComponent("Migrate to nLogin");
-        nlogin.setColor(ChatColor.GREEN);
-        HoverEvent nloginHover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("§6nLogin §7is a §6proprietary §7authentication plugin,\n§7updated and maintained by §bnickuc.com§7. This means that you\n§7cannot view and modify the source code of the plugin.\n\n§eIf you still have questions, please contact us:\n§bnickuc.com/discord"));
-        ClickEvent nloginClick = new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/openlogin nlogin skip");
-        nlogin.setHoverEvent(nloginHover);
-        nlogin.setClickEvent(nloginClick);
-        first.addExtra(nlogin);
-        first.addExtra("              ");
-
-        TextComponent openlogin = new TextComponent("Keep OpeNLogin");
-        openlogin.setColor(ChatColor.DARK_GRAY);
-        HoverEvent openloginHover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("§7Continue using OpeNLogin."));
-        ClickEvent openloginClick = new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/openlogin nlogin_ad");
-        openlogin.setHoverEvent(openloginHover);
-        openlogin.setClickEvent(openloginClick);
-        first.addExtra(openlogin);
-
-        TextComponent second = new TextComponent("       ");
-
-        TextComponent proprietary = new TextComponent("(recommended)");
-        proprietary.setColor(ChatColor.BLUE);
-        proprietary.setHoverEvent(nloginHover);
-        proprietary.setClickEvent(nloginClick);
-        second.addExtra(proprietary);
-
-        // start
-        player.sendMessage("");
-        player.sendMessage(" §6nLogin §7is a free proprietary auth plugin with §6more features§7.");
-        player.sendMessage(" §7When you click to migrate, the plugin will be installed");
-        player.sendMessage(" §7on the next restart. No data will be lost.");
-        player.sendMessage("");
-
-        Player.Spigot spigot = player.spigot();
-        spigot.sendMessage(first);
-        spigot.sendMessage(second);
-
-        player.sendMessage("");
-    }
-
 }

--- a/openlogin-common/src/main/java/com/nickuc/openlogin/common/settings/Settings.java
+++ b/openlogin-common/src/main/java/com/nickuc/openlogin/common/settings/Settings.java
@@ -37,10 +37,6 @@ public enum Settings {
             "languageFile",
             "messages_en.yml"
     ),
-    ALLOW_ADVERTISING(
-            "allow-advertising",
-            true
-    ),
     TIME_TO_LOGIN(
             "Security.time-to-login",
             45

--- a/openlogin-common/src/main/resources/com/nickuc/openlogin/config/config.yml
+++ b/openlogin-common/src/main/resources/com/nickuc/openlogin/config/config.yml
@@ -15,10 +15,6 @@ file-version: 1
 # For more information: https://github.com/nickuc/OpeNLogin/blob/master/docs/lang.md
 languageFile: 'messages_en.yml'
 
-# The plugin will be able to send advertisements to the administrators.
-# For example: nLogin recommendation.
-allow-advertising: true
-
 # Security system related settings.
 Security:
   # Amount of time for a player to log in/register (set in seconds).


### PR DESCRIPTION
It came to our attention that there was an `allow-advertising` configuration option that—and we say this with the utmost respect—appeared to be purely aspirational in nature. The setting was defined, documented, and ready to go, but the actual advertising code... well, let's just say it had a very independent spirit and did whatever it wanted regardless of that toggle's value.
Changes
- Removed sendPluginAd() method that was living its best life without permission checks
- Removed the nlogin_ad command that players could click to silence advertisements they were receiving anyway
- Removed the ALLOW_ADVERTISING setting—now truly useless, instead of just philosophically useless
- Cleaned up PlayerAuthenticateListener to stop checking timestamps and plugin settings for a feature that wasn't even listening to the config