### PR TITLE
fix: correct inverted logic in ConsoleFilter

### DIFF
--- a/common/src/main/java/com/nickuc/openlogin/common/security/filter/ConsoleFilter.java
+++ b/common/src/main/java/com/nickuc/openlogin/common/security/filter/ConsoleFilter.java
@@ -31,11 +31,15 @@ public class ConsoleFilter implements Filter {
 
     @Override
     public boolean isLoggable(LogRecord logRecord) {
-        if (logRecord == null || logRecord.getMessage() == null || LoggerFilterManager.isOpenLoginCommand(logRecord.getMessage())) {
-            return true;
+        if (logRecord == null || logRecord.getMessage() == null) {
+            return false;
         }
 
-        logRecord.setMessage("[OpeNLogin] This content has been filtered.");
-        return false;
+        if (LoggerFilterManager.isOpenLoginCommand(logRecord.getMessage())) {
+            logRecord.setMessage("[OpeNLogin] This content has been filtered.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/common/src/main/java/com/nickuc/openlogin/common/security/filter/ConsoleFilter.java
+++ b/common/src/main/java/com/nickuc/openlogin/common/security/filter/ConsoleFilter.java
@@ -32,7 +32,7 @@ public class ConsoleFilter implements Filter {
     @Override
     public boolean isLoggable(LogRecord logRecord) {
         if (logRecord == null || logRecord.getMessage() == null) {
-            return false;
+            return true;
         }
 
         if (LoggerFilterManager.isOpenLoginCommand(logRecord.getMessage())) {


### PR DESCRIPTION
## Description
Fixed inverted logic in `ConsoleFilter.isLoggable()` that was:
- **Allowing** login/register commands (plaintext passwords) to pass through to logs
- **Blocking** legitimate log messages

## Background
`LoggerFilterManager.setup()` tries Log4J filter first (`Log4JFilter`),
and falls back to `ConsoleFilter` only on servers without Log4J.
The `Log4JFilter` already handles this correctly (DENY for commands with passwords).

## Security Impact
**Limited** — most modern Paper/Spigot servers use Log4J, where the filter
works correctly. The bug only affects servers running on older Bukkit/Spigot
versions that rely on `java.util.logging` (no Log4J). In those cases,
passwords sent via `/login <password>` could leak to server logs.

## Fix
Aligned the `ConsoleFilter` logic with the already-correct `Log4JFilter`:
- Commands containing passwords → DENY (replaced with placeholder)
- All other log messages → ALLOW